### PR TITLE
feature/#6 auth

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -23,6 +23,10 @@ dependencies {
 
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,6 +27,8 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/project/capstone/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/project/capstone/auth/controller/AuthController.java
@@ -1,0 +1,31 @@
+package com.project.capstone.auth.controller;
+
+import com.project.capstone.auth.controller.dto.LoginRequest;
+import com.project.capstone.auth.controller.dto.SignupRequest;
+import com.project.capstone.auth.service.AuthService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/signup")
+    public ResponseEntity<?> signup(@RequestBody SignupRequest request) {
+        authService.signup(request);
+        return ResponseEntity.ok().body("ok");
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+        authService.login(request);
+        return ResponseEntity.ok().body("ok");
+    }
+}

--- a/backend/src/main/java/com/project/capstone/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/project/capstone/auth/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.project.capstone.auth.controller;
 
 import com.project.capstone.auth.controller.dto.LoginRequest;
 import com.project.capstone.auth.controller.dto.SignupRequest;
+import com.project.capstone.auth.controller.dto.TokenResponse;
 import com.project.capstone.auth.service.AuthService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -20,12 +21,13 @@ public class AuthController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody SignupRequest request) {
         authService.signup(request);
-        return ResponseEntity.ok().body("ok");
+        TokenResponse tokenResponse = authService.login(request.email());
+        return ResponseEntity.ok().body(tokenResponse);
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
-        authService.login(request);
-        return ResponseEntity.ok().body("ok");
+    public ResponseEntity<TokenResponse> login(@RequestBody LoginRequest request) {
+        TokenResponse tokenResponse = authService.login(request.email());
+        return ResponseEntity.ok().body(tokenResponse);
     }
 }

--- a/backend/src/main/java/com/project/capstone/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/project/capstone/auth/controller/AuthController.java
@@ -19,7 +19,7 @@ public class AuthController {
     private final AuthService authService;
 
     @PostMapping("/signup")
-    public ResponseEntity<?> signup(@RequestBody SignupRequest request) {
+    public ResponseEntity<TokenResponse> signup(@RequestBody SignupRequest request) {
         authService.signup(request);
         TokenResponse tokenResponse = authService.login(request.email());
         return ResponseEntity.ok().body(tokenResponse);

--- a/backend/src/main/java/com/project/capstone/auth/controller/dto/LoginRequest.java
+++ b/backend/src/main/java/com/project/capstone/auth/controller/dto/LoginRequest.java
@@ -1,0 +1,6 @@
+package com.project.capstone.auth.controller.dto;
+
+public record LoginRequest(
+        String email
+) {
+}

--- a/backend/src/main/java/com/project/capstone/auth/controller/dto/SignupRequest.java
+++ b/backend/src/main/java/com/project/capstone/auth/controller/dto/SignupRequest.java
@@ -1,0 +1,9 @@
+package com.project.capstone.auth.controller.dto;
+
+public record SignupRequest(
+        String email,
+        String name,
+        int age,
+        String gender
+) {
+}

--- a/backend/src/main/java/com/project/capstone/auth/controller/dto/TokenResponse.java
+++ b/backend/src/main/java/com/project/capstone/auth/controller/dto/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.project.capstone.auth.controller.dto;
+
+public record TokenResponse(
+        String token
+) {
+}

--- a/backend/src/main/java/com/project/capstone/auth/domain/PrincipalDetails.java
+++ b/backend/src/main/java/com/project/capstone/auth/domain/PrincipalDetails.java
@@ -1,0 +1,49 @@
+package com.project.capstone.auth.domain;
+
+import com.project.capstone.member.domain.Member;
+import lombok.AllArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@AllArgsConstructor
+public class PrincipalDetails implements UserDetails {
+
+    private Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return null;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getEmail();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/backend/src/main/java/com/project/capstone/auth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/project/capstone/auth/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,37 @@
+package com.project.capstone.auth.jwt;
+
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = jwtProvider.resolveToken(request);
+        try {
+            String email = jwtProvider.validateTokenAndGetEmail(token);
+            Authentication authentication = jwtProvider.createAuthentication(email);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        } catch (Exception e) {
+            log.warn(e.getMessage());
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/backend/src/main/java/com/project/capstone/auth/jwt/JwtProvider.java
+++ b/backend/src/main/java/com/project/capstone/auth/jwt/JwtProvider.java
@@ -1,0 +1,57 @@
+package com.project.capstone.auth.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.security.Key;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+    private Key key;
+    private static final int EXPIRED_DURATION = 24;
+
+    @PostConstruct
+    private void init() {
+        key = Keys.hmacShaKeyFor(secret.getBytes());
+    }
+
+    public String generate(String email) {
+        Claims claims = Jwts.claims();
+        claims.put("email", email);
+        return generateToken(claims);
+    }
+
+    private String generateToken(Claims claims) {
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(issueAt())
+                .setExpiration(expireAt())
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+    }
+
+    private Date expireAt() {
+        LocalDateTime now = LocalDateTime.now();
+        log.info(Date.from(now.plusHours(EXPIRED_DURATION).atZone(ZoneId.systemDefault()).toInstant()).toString());
+        return Date.from(now.plusHours(EXPIRED_DURATION).atZone(ZoneId.systemDefault()).toInstant());
+    }
+
+    private Date issueAt() {
+        LocalDateTime now = LocalDateTime.now();
+        log.info(Date.from(now.atZone(ZoneId.systemDefault()).toInstant()).toString());
+        return Date.from(now.atZone(ZoneId.systemDefault()).toInstant());
+    }
+}

--- a/backend/src/main/java/com/project/capstone/auth/service/AuthService.java
+++ b/backend/src/main/java/com/project/capstone/auth/service/AuthService.java
@@ -1,0 +1,26 @@
+package com.project.capstone.auth.service;
+
+import com.project.capstone.auth.controller.dto.LoginRequest;
+import com.project.capstone.auth.controller.dto.SignupRequest;
+import com.project.capstone.member.domain.Member;
+import com.project.capstone.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final MemberRepository memberRepository;
+    public void signup(SignupRequest request) {
+        if (memberRepository.findMemberByEmail(request.email()).isPresent()) {
+            throw new RuntimeException("이메일이 이미 존재합니다.");
+        }
+        memberRepository.save(new Member(request));
+    }
+    public void login(LoginRequest request) {
+        if (memberRepository.findMemberByEmail(request.email()).isEmpty()) {
+            throw new RuntimeException("이메일이 존재하지 않습니다.");
+        }
+    }
+}

--- a/backend/src/main/java/com/project/capstone/auth/service/AuthService.java
+++ b/backend/src/main/java/com/project/capstone/auth/service/AuthService.java
@@ -1,26 +1,34 @@
 package com.project.capstone.auth.service;
 
-import com.project.capstone.auth.controller.dto.LoginRequest;
 import com.project.capstone.auth.controller.dto.SignupRequest;
+import com.project.capstone.auth.controller.dto.TokenResponse;
+import com.project.capstone.auth.jwt.JwtProvider;
 import com.project.capstone.member.domain.Member;
 import com.project.capstone.member.domain.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
 public class AuthService {
 
     private final MemberRepository memberRepository;
+    private final JwtProvider jwtProvider;
     public void signup(SignupRequest request) {
         if (memberRepository.findMemberByEmail(request.email()).isPresent()) {
             throw new RuntimeException("이메일이 이미 존재합니다.");
         }
         memberRepository.save(new Member(request));
     }
-    public void login(LoginRequest request) {
-        if (memberRepository.findMemberByEmail(request.email()).isEmpty()) {
-            throw new RuntimeException("이메일이 존재하지 않습니다.");
-        }
+    @Transactional
+    public TokenResponse login(String email) {
+        Member member = memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new RuntimeException("이메일이 존재하지 않습니다."));
+        return new TokenResponse(generateToken(member));
+    }
+
+    private String generateToken(Member member) {
+        return jwtProvider.generate(member.getEmail());
     }
 }

--- a/backend/src/main/java/com/project/capstone/auth/service/PrincipalDetailService.java
+++ b/backend/src/main/java/com/project/capstone/auth/service/PrincipalDetailService.java
@@ -1,0 +1,22 @@
+package com.project.capstone.auth.service;
+
+import com.project.capstone.auth.domain.PrincipalDetails;
+import com.project.capstone.member.domain.Member;
+import com.project.capstone.member.domain.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PrincipalDetailService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+    @Override
+    public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+        Member member = memberRepository.findMemberByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("이메일이 존재하지 않습니다."));
+        return new PrincipalDetails(member);
+    }
+}

--- a/backend/src/main/java/com/project/capstone/config/SecurityConfig.java
+++ b/backend/src/main/java/com/project/capstone/config/SecurityConfig.java
@@ -1,0 +1,36 @@
+package com.project.capstone.config;
+
+import com.project.capstone.auth.jwt.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http.authorizeHttpRequests(authorizeRequest ->
+                authorizeRequest.requestMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/backend/src/main/java/com/project/capstone/member/controller/MemberController.java
+++ b/backend/src/main/java/com/project/capstone/member/controller/MemberController.java
@@ -1,0 +1,18 @@
+package com.project.capstone.member.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/member")
+public class MemberController {
+
+    @GetMapping("/test")
+    public ResponseEntity<?> test() {
+        return ResponseEntity.ok("ok");
+    }
+}

--- a/backend/src/main/java/com/project/capstone/member/domain/Member.java
+++ b/backend/src/main/java/com/project/capstone/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.project.capstone.member.domain;
 
+import com.project.capstone.auth.controller.dto.SignupRequest;
 import com.project.capstone.comment.domain.Comment;
 import com.project.capstone.common.domain.MemberClub;
 import com.project.capstone.content.domain.Content;
@@ -29,6 +30,7 @@ public class Member {
     @GeneratedValue(strategy = GenerationType.UUID)
     @Column(columnDefinition = "BINARY(16)")
     private UUID id;
+    private String email;
     private String name;
     private int age;
     private String gender;
@@ -48,4 +50,9 @@ public class Member {
 
     @OneToMany(mappedBy = "member")
     private List<Content> contents = new ArrayList<>();
+
+    public Member(SignupRequest request) {
+        this(null, request.email(), request.name(), request.age(), request.gender(), "ROLE_USER", null,
+                new ArrayList<>(), new ArrayList<>(), new ArrayList<>(), new ArrayList<>());
+    }
 }

--- a/backend/src/main/java/com/project/capstone/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/project/capstone/member/domain/MemberRepository.java
@@ -1,0 +1,14 @@
+package com.project.capstone.member.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface MemberRepository extends JpaRepository<Member, UUID> {
+
+    Member save(Member member);
+    Optional<Member> findMemberByEmail(String email);
+}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -8,3 +8,6 @@ spring:
   jpa:
     hibernate:
       ddl-auto: create
+
+jwt:
+  secret: gDpXHGuTSnwn6IkHoQE0TyrHT4qGDsbAm6L21qSbzUe8s/Nvo2JsiJyawX8fvUD6 Nh4CdIeQxAqnAzysgk+nUw==


### PR DESCRIPTION
## 작업한 내용
- 회원가입, 로그인
- jwt발급
- 요청시 토큰 검사
## 상세 내용
![image](https://github.com/kookmin-sw/capstone-2024-39/assets/123823693/3ef68aed-48ea-44e6-8675-6007faac4787)
- 로그인 요청시 email만 JSON으로 body에 담아 보내면 된다.

![image](https://github.com/kookmin-sw/capstone-2024-39/assets/123823693/ffccda5e-eb53-4b9b-b6cd-a40063e5cb22)
- 로그인 실패 시(테이블에 해당 이메일이 존재하지 않는 경우) 위의 정보들로 요청을 보내면 된다.

![image](https://github.com/kookmin-sw/capstone-2024-39/assets/123823693/481e1e41-1d49-4ee0-816c-bf482824bbc4)
- 로그인이나 회원가입 성공 시 응답이다.

![image](https://github.com/kookmin-sw/capstone-2024-39/assets/123823693/78ddfa96-179a-4d7a-a098-2541653d8762)
- 스프링 시큐리티는 기본적으로 보안에 관련된 필터들(filterchain)을 제공하고, 모든 요청들은 filterchain을 통과한다.
- 인증은 토큰을 검사하는 커스텀 필터(위의 이미지)를 만들고 filterchain에 삽입하는 방식이다. 이때 인증이 필요없는 요청들 또한 해당 필터를 통과하기 때문에, 인증에 실패하더라도 컨트롤러단으로 넘어갈 수 있게 하는 별도의 설정이 필요하다.

## 추가 작업 고려사항
- 로그인의 경우 이메일만 보내면 토큰이 바로 발급되기 때문에 추가적인 보안 장치가 필요하다.
- 현재 예외처리는 단순히 메세지만 보내는 형식인데 프론트에 일관된 예외 응답을 보내야 한다. -> 어느정도 기능 구현이 되었을때 할 예정
